### PR TITLE
Add a 'change' trigger to range checkboxes

### DIFF
--- a/src/jquery.checkboxes.js
+++ b/src/jquery.checkboxes.js
@@ -76,7 +76,8 @@
                         end = Math.max(from, to) + 1;
                     $checkboxes.slice(start, end)
                         .filter(':not(:disabled)')
-                        .prop('checked', $checkbox.prop('checked'));
+                        .prop('checked', $checkbox.prop('checked'))
+                        .trigger('change');
                 }
                 instance.$last = $checkbox;
             });


### PR DESCRIPTION
When a user currently shift-selects a collection of boxes, the 'change'
trigger is only called for the one that they actually clicked on, even
though many boxes may have been updated. This causes problems when
trying to do something based on the contents of each checked box.

This commit triggers the change event of every box that the library
checks so that listeners are aware of the change.

Note that this may cause slowness when users range-select hundreds/
thousands of items.

For details, see GH issue #8

Note that this PR is untested, the project I initially needed this for was never completed, so I don't have a testbed setup, it should work without issues based on my notes in the GH issue though (I made sure to document all my experiences in the comments)
