### PR TITLE
only work on visible checkboxes

### DIFF
--- a/src/jquery.checkboxes.js
+++ b/src/jquery.checkboxes.js
@@ -21,6 +21,7 @@
   Checkboxes.prototype.check = function () {
     this.$context.find(':checkbox')
       .filter(':not(:disabled)')
+      .filter(':visible')
       .prop('checked', true);
   };
 
@@ -30,6 +31,7 @@
   Checkboxes.prototype.uncheck = function () {
     this.$context.find(':checkbox')
       .filter(':not(:disabled)')
+      .filter(':visible')
       .prop('checked', false);
   };
 
@@ -39,6 +41,7 @@
   Checkboxes.prototype.toggle = function () {
     this.$context.find(':checkbox')
       .filter(':not(:disabled)')
+      .filter(':visible')
       .each(function () {
         var $checkbox = $(this);
         $checkbox.prop('checked', !$checkbox.is(':checked'));


### PR DESCRIPTION
Pretty useful additional feature. I use it with to create tables of thousands of checkboxes, which I filter using tablesorter, then "check all" using your plugin.. then you can filter on something else and "check all" again... with expected results.. 

Thanks for your work.

-FT